### PR TITLE
Add CLI option to allow a zip file containing keys instead of using a local or internet based Web server

### DIFF
--- a/ra1nsn0w/main.cpp
+++ b/ra1nsn0w/main.cpp
@@ -23,6 +23,7 @@ extern "C"{
 #include <algorithm>
 #include <cctype>
 
+#include <stdlib.h>
 #include <string.h>
 #include <fcntl.h>
 #include <sys/stat.h>
@@ -147,6 +148,7 @@ int main_r(int argc, const char * argv[]) {
     const char *apticketPath = NULL;
     const char *buildid = NULL;
     const char *variant = NULL;
+    char *zippath = NULL;
     uint64_t ecid = 0;
     bool waitForDevice = false;
     
@@ -237,6 +239,15 @@ int main_r(int argc, const char * argv[]) {
                 break;
             case 'w':// long option: "wait"
                 waitForDevice = true;
+                break;
+            case 'z':// long option: "keys-zip"
+                zippath = realpath(optarg, NULL);
+                if(zippath == NULL) {
+                    error("Unable to locate key zipfile at %s\n", optarg);
+                    return -6;
+                }
+                cfg.customKeysZipUrl = std::string("file://") + std::string(zippath);
+                free(zippath);
                 break;
             case 'h': // long option: "help"
                 cmd_help();

--- a/ra1nsn0w/ra1nsn0w_plugins.cpp
+++ b/ra1nsn0w/ra1nsn0w_plugins.cpp
@@ -37,6 +37,7 @@ static struct option defaultLongopts[] = {
 
     /* Behavior config: */
     { "variant",                        required_argument,      NULL, 'V' },
+    { "keys-zip",                       required_argument,      NULL, 'z' },
     { "nobootx",                        no_argument,            NULL,  0  },
     { "just-dfu",                       no_argument,            NULL,  0  },
     { "just-iboot",                     no_argument,            NULL,  0  },
@@ -127,6 +128,7 @@ static const char defaultHelpScreen[] =
 "      --ota\t\t\t\t\tFirmwarefile is ota.zip rather than firmware.ipsw\n" \
 "\nBehavior config:\n" \
 "  -V, --variant <VARIANT>\t\t\tSpecify restore variant to use\n" \
+"  -z, --keys-zip <path>\t\t\t\tSpecify a zip file containing key json data, instead of using an online database or local server\n" \
 "      --decrypt-devicetree\t\t\tSend devicetree decrypted (Usually we wouldn't touch that)\n" \
 "      --iboot-as-ibect\t\t\t\tBoot iBoot instead of iBEC\n" \
 "      --just-dfu\t\t\t\tStop in DFU mode\n" \
@@ -372,7 +374,7 @@ static void updateLongopts(void){
 
 #pragma mark public
 const char *ra1nsn0w::getShortOpts(void){
-    return "ht:B:e:wv:k:r:s:c:l:b:V:";
+    return "ht:B:e:wv:k:r:s:c:l:b:V:z:";
 }
 
 const struct option *ra1nsn0w::getLongOpts(void){


### PR DESCRIPTION
This will allow the use of e.g. `gaster` to extract keys and then assemble a key file dynamically as-needed, obviating the need to obtain keys from somewhere else.